### PR TITLE
Made debugging available globally, without a need to require in every namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ Add the dependency and the middleware, e.g. in your `:user` profile:
     [com.gfredericks.debug-repl/wrap-debug-repl]}
 ```
 
-Then when you're ready to set breakpoints:
+Then when you're ready to set breakpoints (you may need to reload your
+namespaces or do `(use 'clojure.core :reload)` first):
 
 ``` clojure
-user> (require '[com.gfredericks.debug-repl :refer [break! unbreak!]])
-nil
 user> (let [x 41] (break!))
 Hijacking repl for breakpoint: unnamed
 user> (inc x)

--- a/src/com/gfredericks/debug_repl.clj
+++ b/src/com/gfredericks/debug_repl.clj
@@ -212,6 +212,7 @@
         (wrap-eval)
         (handler))))
 
+(declare global-debug!)
 (defn wrap-debug-repl
   [handler]
   ;; Test for NREPL-53 at startup
@@ -220,6 +221,7 @@
          (when (= ::bad-middleware-ordering (:type (ex-data e)))
            (report-nrepl-53-bug))))
 
+  (global-debug!)
   ;; having handle-debug as a separate function makes it easier to do
   ;; interactive development on this middleware
   (fn [msg] (handle-debug handler msg)))
@@ -237,3 +239,9 @@
   after unbreaking."
   [& body]
   `(try ~@body (catch Throwable ~'&ex (./break!) (throw ~'&ex))))
+
+(defn global-debug! []
+  (intern 'clojure.core 'break! @#'break!) (.setMacro (find-var 'clojure.core/break!))
+  (intern 'clojure.core 'unbreak! @#'unbreak!)
+  (intern 'clojure.core 'unbreak!! @#'unbreak!!)
+  (intern 'clojure.core 'catch-break! @#'catch-break!) (.setMacro (find-var 'clojure.core/catch-break!)))


### PR DESCRIPTION
It is really inconvenient having to require com.gfredericks.debug-repl in every namespace while you debugging, especially given usually one has debug-repl in their user profile, not in a project definition, so having that `require`s permanently in every namespace in most cases won't work.

This patch adds `break!`, `unbreak!`, `unbreak!!` and `catch-break!` to clojure.core before nrepl middleware is installed. 

I chose immediate global installation rather then on-demand global installation because functions/macros will be available only to namespaces that are defined afterward unless those namespaces are manually reloaded (or unless you call `(use 'clojure.core :reload)` when in that namespace).

It doesn't modify any existing functions in clojure.core, only adds new ones, so it should be safe. Given debug-repl is a development tool I think it's ok to tinker with internals a little when it will lead to better development experience.