### PR TITLE
Fix incorrect behavior in nested catch-break! scenario.

### DIFF
--- a/src/com/gfredericks/debug_repl/async.clj
+++ b/src/com/gfredericks/debug_repl/async.clj
@@ -41,11 +41,12 @@
           [(first body) (next body)]
           ["catch-break!" body])]
     `(try ~@body (catch Throwable ~'&ex
-                   (reset! debug-repl/break-return ::throw)
+                   (swap! debug-repl/break-return conj ::throw)
                    (break! ~name)
-                   (if (= ::throw @debug-repl/break-return)
-                     (throw ~'&ex)
-                     @debug-repl/break-return)))))
+                   (let [return# (peek @debug-repl/break-return)]
+                     (if (= ::throw return#)
+                       (throw ~'&ex)
+                       return#))))))
 
 (defn wait-for-breaks
   "Wait for a call to break! outside of the nREPL.  Takes an optional timeout

--- a/src/com/gfredericks/debug_repl/async.clj
+++ b/src/com/gfredericks/debug_repl/async.clj
@@ -44,6 +44,7 @@
                    (swap! debug-repl/break-return conj ::throw)
                    (break! ~name)
                    (let [return# (peek @debug-repl/break-return)]
+                     (swap! break-return pop)
                      (if (= ::throw return#)
                        (throw ~'&ex)
                        return#))))))


### PR DESCRIPTION
I think the only race condition left in this is a very subtle one. The only way I can see for this to go wrong is if a `catch-break!` were triggered by another thread after a between the call to `return!` and the time that catch-break captures `return# (peek @debug-repl/break-return)`. I'm not sure how to address that or even what the overall debug-repl behavior in that situation would be, but I think this change fixes 99% of possible issues.